### PR TITLE
vscode e2e flake fix - increase timeout on inputbox

### DIFF
--- a/changelog.d/+vscode-e2e-flake.internal.md
+++ b/changelog.d/+vscode-e2e-flake.internal.md
@@ -1,0 +1,1 @@
+vscode e2e flake fix - increase timeout on inputbox

--- a/vscode-ext/package.json
+++ b/vscode-ext/package.json
@@ -90,7 +90,7 @@
 		"ts-loader": "^9.4.2",
 		"typescript": "^4.5.4",
 		"@vscode/vsce": "^2.9.2",
-		"vscode-extension-tester": "^5.6.0",
+		"vscode-extension-tester": "^5.7.0",
 		"webpack": "^5.76.0",
 		"webpack-cli": "^5.0.1"
 	},

--- a/vscode-ext/src/tests/e2e.ts
+++ b/vscode-ext/src/tests/e2e.ts
@@ -78,7 +78,7 @@ describe("mirrord sample flow test", function () {
         await setBreakPoint(fileName, browser, defaultTimeout);
         await startDebugging();
 
-        const inputBox = await InputBox.create();
+        const inputBox = await InputBox.create(10000);
         // assertion that podToSelect is not undefined is done in "before" block   
         await browser.driver.wait(async () => {
             return await inputBox.isDisplayed();


### PR DESCRIPTION
Thank you for contributing to mirrord!

Please make sure you added a CHANGELOG file in `changelog.d/` named `issue_number.category.md`.
For example, `1054.changed.md` or `+towncrier.added.md` (if no issue).